### PR TITLE
feat(RoutableInterface): remove container argument

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,6 @@
   "description": "Supports route handling interoperability.",
   "type": "library",
   "require-dev": {
-    "ext-ast": "*",
-    "ext-openssl": "*",
     "squizlabs/php_codesniffer": "^3.7"
   },
   "autoload": {
@@ -17,16 +15,10 @@
     "sort-packages": true
   },
   "require": {
-    "php": ">=8.1",
-    "psr/container": "^2.0"
+    "php": ">=8.1"
   },
   "license": "MIT",
   "scripts": {
-    "check": [
-      "@lint -q",
-      "@semgrep",
-      "@smell"
-    ],
     "ci:lint": "composer exec \"@lint\"",
     "ci:lint-fix": "composer exec \"@lint-fix\"",
     "lint": "phpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,62 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77394354412f5f48bdebf5cdae76c2dc",
-    "packages": [
-        {
-            "name": "psr/container",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.2"
-            },
-            "time": "2021-11-05T16:47:00+00:00"
-        }
-    ],
+    "content-hash": "5631f3d49e4d78e39dfa6bc994a92479",
+    "packages": [],
     "packages-dev": [
         {
             "name": "squizlabs/php_codesniffer",
@@ -127,9 +73,6 @@
     "platform": {
         "php": ">=8.1"
     },
-    "platform-dev": {
-        "ext-ast": "*",
-        "ext-openssl": "*"
-    },
+    "platform-dev": [],
     "plugin-api-version": "2.3.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,6 @@
     <description>The coding standard for Phpolar.</description>
 
     <file>src</file>
-    <file>tests</file>
 
     <arg name="basepath" value="."/>
     <arg name="extensions" value="php"/>

--- a/src/RoutableInterface.php
+++ b/src/RoutableInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Phpolar\Routable;
 
-use Psr\Container\ContainerInterface;
-
 /**
  * Defines what should be done when a request is received.
  *
@@ -35,7 +33,7 @@ interface RoutableInterface
      * class PathWithIdDelegate implements RoutableInterface
      * {
      *     // Define route parameters as optional arguments in the child class.
-     *     public function process(ContainerInterface $container, string $id = ""): string
+     *     public function process(string $id = ""): string
      *     {
      *         // ...
      *     }
@@ -47,7 +45,7 @@ interface RoutableInterface
      * class PathWithNameDelegate implements RoutableInterface
      * {
      *     // Define route parameters as optional arguments in the child class.
-     *     public function process(ContainerInterface $container, string $name = ""): string
+     *     public function process(string $name = ""): string
      *     {
      *         // ...
      *     }
@@ -55,5 +53,5 @@ interface RoutableInterface
      *
      * ```
      */
-    public function process(ContainerInterface $container): string;
+    public function process(): string;
 }


### PR DESCRIPTION
Requiring the container as an argument makes testing cumbersome.  Due, in part, to PHP's lack of generics, type safety within the class scope suffers when the service locator pattern is used.  See https://github.com/phpolar/phpolar/issues/258.

BREAKING CHANGE: A PSR-11 `Container` is no longer required as an argument to the `process` method.